### PR TITLE
Add endpoint for fetching the 9 latest events from the API (#16)

### DIFF
--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -65,7 +65,7 @@ class EventController extends Controller
 
     public function latest()
     {
-        $events = Event::latest()->limit(10)->get();
+        $events = Event::latest()->limit(9)->get();
 
         return response()->json(['events' => $events], 200);
     }

--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -62,4 +62,11 @@ class EventController extends Controller
     {
         //
     }
+
+    public function latest()
+    {
+        $events = Event::latest()->limit(10)->get();
+
+        return response()->json(['events' => $events], 200);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,4 +17,5 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
 
+Route::get('/events/latest', 'Api\EventController@latest')->name('events.latest');
 Route::resource('/events', 'Api\EventController')->only('show');

--- a/tests/Feature/GetLatestEventsTest.php
+++ b/tests/Feature/GetLatestEventsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\Event;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class GetLatestEventsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function get_latest_events()
+    {
+        $olderEvents = factory(Event::class, 15)->create(['created_at' => now()->subDays(15)]);
+        $latestEvents = factory(Event::class, 15)->create(['created_at' => now()->subDays(5)]);
+
+        $response = $this->getJson('/api/events/latest')
+            ->assertSuccessful()
+            ->assertJsonFragment([
+                'slug' => $latestEvents[0]->slug,
+                'slug' => $latestEvents[9]->slug,
+            ])
+            ->assertJsonMissing([
+                'slug' => $latestEvents[10]->slug,
+                'slug' => $olderEvents[0]->slug,
+            ]);
+
+        $this->assertEquals(10, count($response->getData()->events));
+    }
+}

--- a/tests/Feature/GetLatestEventsTest.php
+++ b/tests/Feature/GetLatestEventsTest.php
@@ -14,20 +14,20 @@ class GetLatestEventsTest extends TestCase
     /** @test */
     public function get_latest_events()
     {
-        $olderEvents = factory(Event::class, 15)->create(['created_at' => now()->subDays(15)]);
-        $latestEvents = factory(Event::class, 15)->create(['created_at' => now()->subDays(5)]);
+        $olderEvents = factory(Event::class, 10)->create(['created_at' => now()->subDays(15)]);
+        $latestEvents = factory(Event::class, 10)->create(['created_at' => now()->subDays(5)]);
 
         $response = $this->getJson('/api/events/latest')
             ->assertSuccessful()
             ->assertJsonFragment([
                 'slug' => $latestEvents[0]->slug,
-                'slug' => $latestEvents[9]->slug,
+                'slug' => $latestEvents[8]->slug,
             ])
             ->assertJsonMissing([
-                'slug' => $latestEvents[10]->slug,
+                'slug' => $latestEvents[9]->slug,
                 'slug' => $olderEvents[0]->slug,
             ]);
 
-        $this->assertEquals(10, count($response->getData()->events));
+        $this->assertEquals(9, count($response->getData()->events));
     }
 }


### PR DESCRIPTION
Implements endpoint for fetching the 9 latest events from our API.

Fix #16 